### PR TITLE
removed name for github_repository_webhook resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,6 @@ provider "github" {
 resource "github_repository_webhook" "default" {
   count = "${var.enabled == "true" && length(var.github_repositories) > 0 ? length(var.github_repositories) : 0}"
 
-  name       = "${var.name}"
   repository = "${var.github_repositories[count.index]}"
   active     = "${var.active}"
 


### PR DESCRIPTION
Problem : 

There is no `name` field for `github_repository_webhooks` resource.

Solution:

`name` field has been removed

Source : https://www.terraform.io/docs/providers/github/r/repository_webhook.html