### PR TITLE
Make `github_token` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
  [![Build Status](https://travis-ci.org/cloudposse/terraform-github-repository-webhooks.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-github-repository-webhooks) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-github-repository-webhooks.svg)](https://github.com/cloudposse/terraform-github-repository-webhooks/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Terraform module to provision webhooks on a set of GitHub repositories. 
+Terraform module to provision webhooks on a set of GitHub repositories.
 This is useful if you need to register a webhook en masse across dozens of repositories.
 
 
@@ -54,13 +54,13 @@ Create a GitHub Personal Access Token that has `admin:repo_hook` for full contro
 
 ```hcl
 module "github_webhooks" {
-  source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=master"
-  github_organization = "cloudposse"
-  github_token        = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-  github_repositories = "geodesic"
-  webhook_url         = "https://atlantis.prod.company.com/"
-  content_type        = "application/json"
-  events              = ["issues"]
+  source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=master"
+  github_organization  = "cloudposse"
+  github_token         = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  github_repositories  = "geodesic"
+  webhook_url          = "https://atlantis.prod.company.com/"
+  webhook_content_type = "application/json"
+  events               = ["issues"]
 }
 ```
 
@@ -83,12 +83,12 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| active | Indicate of the webhook should receive events. | string | `true` | no |
+| active | Indicate of the webhook should receive events | string | `true` | no |
 | enabled | Whether or not to enable this module | string | `true` | no |
 | events | A list of events which should trigger the webhook. | list | `<list>` | no |
-| github_organization | GitHub organization to use when creating webhook | string | - | yes |
+| github_organization | GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list | `<list>` | no |
-| github_token | GitHub token used for API access | string | - | yes |
+| github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | webhook_content_type | Webhook Content Type (E.g. json) | string | `json` | no |
 | webhook_insecure_ssl | Webhook Insecure SSL (E.g. trust self-signed certificates) | string | `false` | no |
 | webhook_secret | Webhook secret | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available targets:
 | active | Indicate of the webhook should receive events | string | `true` | no |
 | enabled | Whether or not to enable this module | string | `true` | no |
 | events | A list of events which should trigger the webhook. | list | `<list>` | no |
-| github_organization | GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable | string | - | yes |
+| github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | webhook_content_type | Webhook Content Type (E.g. json) | string | `json` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -15,7 +15,7 @@ github_repo: cloudposse/terraform-github-repository-webhooks
 
 # Short description of this project
 description: |-
-  Terraform module to provision webhooks on a set of GitHub repositories. 
+  Terraform module to provision webhooks on a set of GitHub repositories.
   This is useful if you need to register a webhook en masse across dozens of repositories.
 
 # Badges to display
@@ -36,13 +36,13 @@ usage: |-
 
   ```hcl
   module "github_webhooks" {
-    source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=master"
-    github_organization = "cloudposse"
-    github_token        = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-    github_repositories = "geodesic"
-    webhook_url         = "https://atlantis.prod.company.com/"
-    content_type        = "application/json"
-    events              = ["issues"]
+    source               = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=master"
+    github_organization  = "cloudposse"
+    github_token         = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    github_repositories  = "geodesic"
+    webhook_url          = "https://atlantis.prod.company.com/"
+    webhook_content_type = "application/json"
+    events               = ["issues"]
   }
   ```
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,12 +2,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| active | Indicate of the webhook should receive events. | string | `true` | no |
+| active | Indicate of the webhook should receive events | string | `true` | no |
 | enabled | Whether or not to enable this module | string | `true` | no |
 | events | A list of events which should trigger the webhook. | list | `<list>` | no |
-| github_organization | GitHub organization to use when creating webhook | string | - | yes |
+| github_organization | GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list | `<list>` | no |
-| github_token | GitHub token used for API access | string | - | yes |
+| github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | webhook_content_type | Webhook Content Type (E.g. json) | string | `json` | no |
 | webhook_insecure_ssl | Webhook Insecure SSL (E.g. trust self-signed certificates) | string | `false` | no |
 | webhook_secret | Webhook secret | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 | active | Indicate of the webhook should receive events | string | `true` | no |
 | enabled | Whether or not to enable this module | string | `true` | no |
 | events | A list of events which should trigger the webhook. | list | `<list>` | no |
-| github_organization | GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable | string | - | yes |
+| github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | webhook_content_type | Webhook Content Type (E.g. json) | string | `json` | no |

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,5 +1,6 @@
 variable "github_token" {
-  description = "GitHub token used for API access"
+  default     = ""
+  description = "GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
 }
 
 module "webhooks" {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "github_token" {
 }
 
 variable "github_organization" {
-  description = "GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable"
+  description = "GitHub organization to use when creating webhooks"
 }
 
 variable "github_repositories" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,12 @@ variable "enabled" {
 }
 
 variable "github_token" {
-  description = "GitHub token used for API access"
+  default     = ""
+  description = "GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
 }
 
 variable "github_organization" {
-  description = "GitHub organization to use when creating webhook"
+  description = "GitHub organization. The account corresponding to the token will need `owner` privileges for this organization. If not provided, can also be sourced from the `GITHUB_ORGANIZATION` environment variable"
 }
 
 variable "github_repositories" {
@@ -37,7 +38,7 @@ variable "webhook_insecure_ssl" {
 }
 
 variable "active" {
-  description = "Indicate of the webhook should receive events."
+  description = "Indicate of the webhook should receive events"
   default     = true
 }
 


### PR DESCRIPTION
## what
* Make `github_token` optional

## why
* If not provided, can be sourced from the `GITHUB_TOKEN` environment variable
* Sourcing from the `GITHUB_TOKEN` environment variable is useful when the module is provisioned from `geodesic` or CI/CD that have access to the `GITHUB_TOKEN` environment variable, which in turn could be sourced from SSM using `chamber`
