### PR TITLE
feat: allow anonymous access if token not set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 provider "github" {
   token        = var.github_token != "" ? var.github_token : null
   organization = var.github_organization
+  anonymous    = var.github_token != "" ? false : true
 }
 
 resource "github_repository_webhook" "default" {


### PR DESCRIPTION
If this module is used in the [code pipeline module](https://github.com/cloudposse/terraform-aws-ecs-codepipeline) (e.g., in the [ECS web app module](https://github.com/cloudposse/terraform-aws-ecs-web-app)), the provider fails with bad credentials, even if the pipeline or webhooks are disabled.

By setting anonymous access on the provider configuration when the token is not provided, this problem is avoided.

A longer term fix is probably (as others have suggested) to remove the code pipeline from the web app module.