### PR TITLE
fix "protocol scheme" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Available targets:
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
+| github_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`) | bool | `false` | no |
 | github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Available targets:
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
-| github_base_url | GitHub target API endpoint | string | `https://github.com/api/` | no |
+| github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Available targets:
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
+| github_base_url | GitHub target API endpoint | string | `https://github.com/api/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
-| github_base_url | GitHub target API endpoint | string | `https://github.com/api/` | no |
+| github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,6 +5,7 @@
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
+| github_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`) | bool | `false` | no |
 | github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,6 +5,7 @@
 | active | Indicate of the webhook should receive events | bool | `true` | no |
 | enabled | Whether or not to enable this module | bool | `true` | no |
 | events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
+| github_base_url | GitHub target API endpoint | string | `https://github.com/api/` | no |
 | github_organization | GitHub organization to use when creating webhooks | string | - | yes |
 | github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
 | github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "github" {
   token        = var.github_token != "" ? var.github_token : null
   organization = var.github_organization
-  anonymous    = var.github_token != "" ? false : true
+  anonymous    = var.github_anonymous
   base_url     = var.github_base_url
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ provider "github" {
   token        = var.github_token != "" ? var.github_token : null
   organization = var.github_organization
   anonymous    = var.github_token != "" ? false : true
+  base_url     = var.github_base_url
 }
 
 resource "github_repository_webhook" "default" {
@@ -21,6 +22,6 @@ resource "github_repository_webhook" "default" {
 
   lifecycle {
     # This is required for idempotency
-    ignore_changes = ["configuration[0].secret"]
+    ignore_changes = [configuration[0].secret]
   }
 }

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -41,6 +41,7 @@ init: $(BASE)/vendor
 
 .PHONY : test
 ## Run tests
+test: TF_VAR_github_token=$(GITHUB_TOKEN)
 test: init
 	cd $(BASE) && go test -v -timeout 30m -run TestExamplesComplete
 

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -41,7 +41,6 @@ init: $(BASE)/vendor
 
 .PHONY : test
 ## Run tests
-test: TF_VAR_github_token=$(GITHUB_TOKEN)
 test: init
 	cd $(BASE) && go test -v -timeout 30m -run TestExamplesComplete
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -28,7 +28,6 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	webhookUrl := terraform.Output(t, terraformOptions, "webhook_url")
 
-	expectedWebhookUrl := "https://archive.sweetops.com"
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, expectedWebhookUrl, webhookUrl)
+	assert.Regexp(t, "^https://api.github.com/repos/.+/hooks/[0-9]+$", webhookUrl)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "github_base_url" {
   default     = "https://api.github.com/"
 }
 
+variable "github_anonymous" {
+  type        = bool
+  description = "Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`)"
+  default     = false
+}
+
 variable "github_repositories" {
   type        = list(string)
   description = "List of repository names which should be associated with the webhook"

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,6 @@ variable "github_base_url" {
   default     = "https://api.github.com/"
 }
 
-
 variable "github_repositories" {
   type        = list(string)
   description = "List of repository names which should be associated with the webhook"

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "github_organization" {
 variable "github_base_url" {
   type        = string
   description = "GitHub target API endpoint"
-  default     = "https://github.com/api/"
+  default     = "https://api.github.com/"
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,13 @@ variable "github_organization" {
   description = "GitHub organization to use when creating webhooks"
 }
 
+variable "github_base_url" {
+  type        = string
+  description = "GitHub target API endpoint"
+  default     = "https://github.com/api/"
+}
+
+
 variable "github_repositories" {
   type        = list(string)
   description = "List of repository names which should be associated with the webhook"


### PR DESCRIPTION
## what
* `Error: Get /v3/orgs/cloudposse: unsupported protocol scheme ""`

## why
* https://www.terraform.io/docs/providers/github/index.html#argument-reference
* maybe GITHUB_BASE_URL set to empty string by github actions
* Fix test for URL https://www.terraform.io/docs/providers/github/r/repository_webhook.html#url

