### PR TITLE
fix: ensure provider does not use version >= 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,28 +120,42 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| github | >= 2.2, < 2.9 |
+| local | ~> 1.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| github | >= 2.2, < 2.9 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| active | Indicate of the webhook should receive events | bool | `true` | no |
-| enabled | Whether or not to enable this module | bool | `true` | no |
-| events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
-| github_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`) | bool | `false` | no |
-| github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
-| github_organization | GitHub organization to use when creating webhooks | string | - | yes |
-| github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
-| github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
-| webhook_content_type | Webhook Content Type (e.g. `json`) | string | `json` | no |
-| webhook_insecure_ssl | Webhook Insecure SSL (e.g. trust self-signed certificates) | bool | `false` | no |
-| webhook_secret | Webhook secret | string | `` | no |
-| webhook_url | Webhook URL | string | - | yes |
+|------|-------------|------|---------|:--------:|
+| active | Indicate of the webhook should receive events | `bool` | `true` | no |
+| enabled | Whether or not to enable this module | `bool` | `true` | no |
+| events | A list of events which should trigger the webhook. | `list(string)` | <pre>[<br>  "issue_comment",<br>  "pull_request",<br>  "pull_request_review",<br>  "pull_request_review_comment"<br>]</pre> | no |
+| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
+| github\_base\_url | GitHub target API endpoint | `string` | `"https://api.github.com/"` | no |
+| github\_organization | GitHub organization to use when creating webhooks | `string` | n/a | yes |
+| github\_repositories | List of repository names which should be associated with the webhook | `list(string)` | `[]` | no |
+| github\_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |
+| webhook\_content\_type | Webhook Content Type (e.g. `json`) | `string` | `"json"` | no |
+| webhook\_insecure\_ssl | Webhook Insecure SSL (e.g. trust self-signed certificates) | `bool` | `false` | no |
+| webhook\_secret | Webhook secret | `string` | `""` | no |
+| webhook\_url | Webhook URL | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| webhook_url | Webhook URL |
+| webhook\_url | Webhook URL |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,23 +1,37 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| github | >= 2.2, < 2.9 |
+| local | ~> 1.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| github | >= 2.2, < 2.9 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| active | Indicate of the webhook should receive events | bool | `true` | no |
-| enabled | Whether or not to enable this module | bool | `true` | no |
-| events | A list of events which should trigger the webhook. | list(string) | `<list>` | no |
-| github_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`) | bool | `false` | no |
-| github_base_url | GitHub target API endpoint | string | `https://api.github.com/` | no |
-| github_organization | GitHub organization to use when creating webhooks | string | - | yes |
-| github_repositories | List of repository names which should be associated with the webhook | list(string) | `<list>` | no |
-| github_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
-| webhook_content_type | Webhook Content Type (e.g. `json`) | string | `json` | no |
-| webhook_insecure_ssl | Webhook Insecure SSL (e.g. trust self-signed certificates) | bool | `false` | no |
-| webhook_secret | Webhook secret | string | `` | no |
-| webhook_url | Webhook URL | string | - | yes |
+|------|-------------|------|---------|:--------:|
+| active | Indicate of the webhook should receive events | `bool` | `true` | no |
+| enabled | Whether or not to enable this module | `bool` | `true` | no |
+| events | A list of events which should trigger the webhook. | `list(string)` | <pre>[<br>  "issue_comment",<br>  "pull_request",<br>  "pull_request_review",<br>  "pull_request_review_comment"<br>]</pre> | no |
+| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
+| github\_base\_url | GitHub target API endpoint | `string` | `"https://api.github.com/"` | no |
+| github\_organization | GitHub organization to use when creating webhooks | `string` | n/a | yes |
+| github\_repositories | List of repository names which should be associated with the webhook | `list(string)` | `[]` | no |
+| github\_token | GitHub token used for API access. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |
+| webhook\_content\_type | Webhook Content Type (e.g. `json`) | `string` | `"json"` | no |
+| webhook\_insecure\_ssl | Webhook Insecure SSL (e.g. trust self-signed certificates) | `bool` | `false` | no |
+| webhook\_secret | Webhook secret | `string` | `""` | no |
+| webhook\_url | Webhook URL | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| webhook_url | Webhook URL |
+| webhook\_url | Webhook URL |
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 0.12.0"
 
   required_providers {
-    github = "~> 2.2"
+    github = ">= 2.2, < 2.9"
     local  = "~> 1.2"
   }
 }


### PR DESCRIPTION
The GitHub provider introduced a breaking change with the minor bump
to version 2.9.0, by removing a number of configuration options. This
included the 'anonymous' flag, which is expected to exist by this
module. Prevent this provder version, or later, from being used for now.
For reference, see
https://github.com/terraform-providers/terraform-provider-github/issues/502.

## what
* Disallow a provider version of 2.9.0 or greater for now

## why
* Ensure the options on the provider needed by this version of the module are still available

## references
* https://github.com/terraform-providers/terraform-provider-github/issues/502

