### PR TITLE
Pin GitHub provider to exactly 3.0.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,10 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/context.tf   @cloudposse/engineering @cloudposse/approvers
-README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
-docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/approvers
+README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 
 # Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
 .github/mergify.yml @cloudposse/admins

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -38,6 +38,8 @@ jobs:
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-github-repository-webhooks/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-github-repository-webhooks&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -119,14 +138,14 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| github | >= 3.0.0 |
+| github | 3.0.0 |
 | local | >= 1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| github | >= 3.0.0 |
+| github | 3.0.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| github | >= 3.0.0 |
+| github | 3.0.0 |
 | local | >= 1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| github | >= 3.0.0 |
+| github | 3.0.0 |
 
 ## Inputs
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,9 @@ clean:
 all: module examples/complete
 
 ## Run basic sanity checks against the module itself
-module: export TESTS ?= installed lint get-modules module-pinning get-plugins provider-pinning validate terraform-docs input-descriptions output-descriptions
+# Skip provider-pinning test, we need to pin GitHub provider
+# module: export TESTS ?= installed lint get-modules module-pinning get-plugins provider-pinning validate terraform-docs input-descriptions output-descriptions
+module: export TESTS ?= installed lint get-modules module-pinning get-plugins validate terraform-docs input-descriptions output-descriptions
 module: deps
 	$(call RUN_TESTS, ../)
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     github = {
-      source  = "hashicorp/github"
-      version = ">= 3.0.0"
+      source = "hashicorp/github"
+      # breaking changes both immediately before and after 3.0.0, pin exactly
+      version = "3.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## what
- Pin GitHub provider to exactly 3.0.0

## why
- Possible fix for https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/63
- Every release of GitHub provider seems to have breaking changes.

## references
- GitHub provider [Changelog](https://github.com/hashicorp/terraform-provider-github/blob/master/CHANGELOG.md#300-september-08-2020)
